### PR TITLE
Fixed parsing of longitude in MSFS flight plans

### DIFF
--- a/scripts/formats/msfs-pln.ts
+++ b/scripts/formats/msfs-pln.ts
@@ -35,8 +35,8 @@ const msfsPln: Format = {
 		const getWaypoint = (atcWaypoint: AtcWaypoint): Waypoint => ({
 			name: atcWaypoint.ICAO?.ICAOIdent ?? atcWaypoint['@id'],
 			type: typeKeyToTypes[atcWaypoint.ATCWaypointType],
-			latitude: pdms2d(atcWaypoint.WorldPosition.split(',')[0]),
-			longitude: pdms2d(atcWaypoint.WorldPosition.split(',')[1])
+			latitude: pdms2d(atcWaypoint.WorldPosition.split(',')[0].trim()),
+			longitude: pdms2d(atcWaypoint.WorldPosition.split(',')[1].trim())
 		})
 
 		return {


### PR DESCRIPTION
Fixes #1 

Splitting of waypoint string by `,` character keeps white space in front of longitude. pdms2d method expects sanitized input, so when there's white space present - it provide `NaN` as result. Fixing behavior of MSFS parser to supply coordinates to parse without whitespace upfront 